### PR TITLE
Make line entry more flexible

### DIFF
--- a/iconoblast
+++ b/iconoblast
@@ -48,7 +48,7 @@ text_position=$(($band_position - 3))
 
 echo "image dimensions ${width}x${height} - band height ${band_height} @ ${band_position} - point size ${point_size}"
 
-convert ${base_path} -blur 10x8 /tmp/blurred.png
+convert ${base_path} -blur 10x3 /tmp/blurred.png
 convert /tmp/blurred.png -gamma 0 -fill white -draw "rectangle 0,$band_position,$width,$height" /tmp/mask.png
 convert -size ${width}x${band_height} xc:none -fill 'rgba(0,0,0,0.2)' -draw "rectangle 0,0,$width,$band_height" /tmp/labels-base.png
 convert -background none -size ${width}x${band_height} -pointsize $point_size -fill white -gravity center -gravity South caption:"$caption" /tmp/labels.png

--- a/iconoblast
+++ b/iconoblast
@@ -7,8 +7,8 @@ if [[ -z `which convert` || -z `which gs` ]]; then
     exit 1
 fi
 
-if [[ -z $1 || -z $2 || -z $3 ]]; then
-    echo "Usage: $0 <icon> <commit> <branch> (<repo>)"
+if [[ -z $1 || -z $2 ]]; then
+    echo "Usage: $0 <icon> <commit> (<branch>) (<repo>)"
     exit 1
 fi
 
@@ -19,8 +19,13 @@ commit=$2
 branch=$3
 repo=$4
 
-line_count=2
-caption="${branch}\n${commit}"
+line_count=1
+caption="${commit}"
+
+if [[ $branch ]]; then
+	caption="${branch}\n${caption}"
+	line_count=$(($line_count + 1))
+fi
 
 if [[ $repo ]]; then
 	caption="${repo}\n${caption}"

--- a/iconoblast
+++ b/iconoblast
@@ -7,8 +7,8 @@ if [[ -z `which convert` || -z `which gs` ]]; then
     exit 1
 fi
 
-if [[ -z $1 || -z $2 || -z $3 || -z $4 ]]; then
-    echo "Usage: $0 <icon> <commit> <branch> <repo>"
+if [[ -z $1 || -z $2 || -z $3 ]]; then
+    echo "Usage: $0 <icon> <commit> <branch> (<repo>)"
     exit 1
 fi
 
@@ -19,9 +19,15 @@ commit=$2
 branch=$3
 repo=$4
 
-caption="${repo}\n${branch}\n${commit}"
-echo "burning caption:"
-echo $caption
+line_count=2
+caption="${branch}\n${commit}"
+
+if [[ $repo ]]; then
+	caption="${repo}\n${caption}"
+	line_count=$(($line_count + 1))
+fi
+
+echo "burning caption ${caption}"
 
 if [[ `uname -s` == 'Darwin' ]]; then
     xcrun -sdk iphoneos pngcrush -revert-iphone-optimizations -q ${base_path} ${base_path}-out
@@ -30,10 +36,10 @@ fi
 
 width=`identify -format %w ${base_path}`
 height=`identify -format %h ${base_path}`
-band_height=$((($height * 47) / 100))
+point_size=$(((13 * $width) / 100))
+band_height=$(($line_count * $point_size + 15))
 band_position=$(($height - $band_height))
 text_position=$(($band_position - 3))
-point_size=$(((13 * $width) / 100))
 
 echo "image dimensions ${width}x${height} - band height ${band_height} @ ${band_position} - point size ${point_size}"
 

--- a/iconoblast
+++ b/iconoblast
@@ -8,19 +8,19 @@ if [[ -z `which convert` || -z `which gs` ]]; then
 fi
 
 if [[ -z $1 || -z $2 ]]; then
-    echo "Usage: $0 <icon> <commit> (<branch>) (<repo>)"
+    echo "Usage: $0 <icon> <version> (<branch>) (<repo>)"
     exit 1
 fi
 
 base_path=$1
 echo "burning file ${base_path}"
 
-commit=$2
+version=$2
 branch=$3
 repo=$4
 
 line_count=1
-caption="${commit}"
+caption="${version}"
 
 if [[ $branch ]]; then
 	caption="${branch}\n${caption}"

--- a/iconoblast
+++ b/iconoblast
@@ -42,7 +42,7 @@ fi
 width=`identify -format %w ${base_path}`
 height=`identify -format %h ${base_path}`
 point_size=$(((13 * $width) / 100))
-band_height=$(($line_count * $point_size + 15))
+band_height=$(($line_count * $point_size + ($height / 10)))
 band_position=$(($height - $band_height))
 text_position=$(($band_position - 3))
 


### PR DESCRIPTION
- Makes `repo` and `branch` parameters optional
- Changes  `commit` parameter name to `version`
- Softens the blur

| ![icon](https://cloud.githubusercontent.com/assets/1198851/13041830/cce56658-d388-11e5-86bf-315d5d23d523.png) | ![icon](https://cloud.githubusercontent.com/assets/1198851/13041866/29ebaf92-d389-11e5-9f4b-9743cf9d1082.png) | ![icon](https://cloud.githubusercontent.com/assets/1198851/13041876/45bf125e-d389-11e5-9e8b-585ff9b1d6ba.png) |
| --- | --- | --- |
|  |  |  |

Fixes #3, #4.

/cc @1ec5
